### PR TITLE
[BUGFIX] Set Edit Submit AJAX Request to POST

### DIFF
--- a/Resources/Public/JavaScript/Vidi/Edit.js
+++ b/Resources/Public/JavaScript/Vidi/Edit.js
@@ -337,6 +337,7 @@ define([
 			$.ajax({
 				url: $('#form-edit', Vidi.modal).attr('action'),
 				data: $('#form-edit', Vidi.modal).serialize(),
+				method: 'POST',
 				beforeSend: function(arr, $form, options) {
 
 					// Only submit if button is not disabled


### PR DESCRIPTION
This Error still occurs in TYPO3 7.6, when trying to submit an Edit Form with a high number of categories.

The proposed Fix changes the Ajax Method on form submit to POST, which circumvents the HTTP414 (Request Too Long) Error on Form Submit.

Fixes https://github.com/fabarea/vidi/issues/110